### PR TITLE
Also send command with left click (attack)

### DIFF
--- a/src/aiptu/smaccer/EventHandler.php
+++ b/src/aiptu/smaccer/EventHandler.php
@@ -131,6 +131,9 @@ class EventHandler implements Listener {
 		$action = Queue::getCurrentAction($playerName);
 
 		if ($action === null) {
+            if ($entity->canExecuteCommands($damager)) {
+                $entity->executeCommands($damager);
+            }
 			$event->cancel();
 			return;
 		}


### PR DESCRIPTION
Added Left Click (attack) support for NPC command execution. NPCs can now run commands when hit, instead of only right-click interaction.

## Summary by Sourcery

New Features:
- Allow NPCs to run their associated commands when damaged by a player's attack (left-click).