### PR TITLE
Add missing entity smaccers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Ignore Composer's vendor directory
-vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Composer's vendor directory
+vendor/

--- a/src/aiptu/smaccer/EventHandler.php
+++ b/src/aiptu/smaccer/EventHandler.php
@@ -131,6 +131,9 @@ class EventHandler implements Listener {
 		$action = Queue::getCurrentAction($playerName);
 
 		if ($action === null) {
+            if ($entity->canExecuteCommands($damager)) {
+                $entity->executeCommands($damager);
+            }
 			$event->cancel();
 			return;
 		}

--- a/src/aiptu/smaccer/entity/SmaccerHandler.php
+++ b/src/aiptu/smaccer/entity/SmaccerHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace aiptu\smaccer\entity;
 
 use aiptu\smaccer\entity\npc\AllaySmaccer;
+use aiptu\smaccer\entity\npc\ArmorStandSmaccer;
 use aiptu\smaccer\entity\npc\ArmadilloSmaccer;
 use aiptu\smaccer\entity\npc\AxolotlSmaccer;
 use aiptu\smaccer\entity\npc\BatSmaccer;
@@ -22,6 +23,8 @@ use aiptu\smaccer\entity\npc\BlazeSmaccer;
 use aiptu\smaccer\entity\npc\BoggedSmaccer;
 use aiptu\smaccer\entity\npc\BreezeSmaccer;
 use aiptu\smaccer\entity\npc\CamelSmaccer;
+use aiptu\smaccer\entity\npc\CamelHuskSmaccer;
+use aiptu\smaccer\entity\npc\CopperGolemSmaccer;
 use aiptu\smaccer\entity\npc\CatSmaccer;
 use aiptu\smaccer\entity\npc\CaveSpiderSmaccer;
 use aiptu\smaccer\entity\npc\ChickenSmaccer;
@@ -33,6 +36,7 @@ use aiptu\smaccer\entity\npc\DolphinSmaccer;
 use aiptu\smaccer\entity\npc\DonkeySmaccer;
 use aiptu\smaccer\entity\npc\DrownedSmaccer;
 use aiptu\smaccer\entity\npc\ElderGuardianSmaccer;
+use aiptu\smaccer\entity\npc\ElderGuardianGhostSmaccer;
 use aiptu\smaccer\entity\npc\EnderDragonSmaccer;
 use aiptu\smaccer\entity\npc\EndermanSmaccer;
 use aiptu\smaccer\entity\npc\EndermiteSmaccer;
@@ -43,6 +47,7 @@ use aiptu\smaccer\entity\npc\GhastSmaccer;
 use aiptu\smaccer\entity\npc\GlowSquidSmaccer;
 use aiptu\smaccer\entity\npc\GoatSmaccer;
 use aiptu\smaccer\entity\npc\GuardianSmaccer;
+use aiptu\smaccer\entity\npc\HappyGhastSmaccer;
 use aiptu\smaccer\entity\npc\HoglinSmaccer;
 use aiptu\smaccer\entity\npc\HorseSmaccer;
 use aiptu\smaccer\entity\npc\HuskSmaccer;
@@ -93,6 +98,7 @@ use aiptu\smaccer\entity\npc\WolfSmaccer;
 use aiptu\smaccer\entity\npc\ZoglinSmaccer;
 use aiptu\smaccer\entity\npc\ZombieHorseSmaccer;
 use aiptu\smaccer\entity\npc\ZombieSmaccer;
+use aiptu\smaccer\entity\npc\ZombiePigmanSmaccer;
 use aiptu\smaccer\entity\npc\ZombieVillagerSmaccer;
 use aiptu\smaccer\entity\npc\ZombieVillagerV2Smaccer;
 use aiptu\smaccer\entity\utils\EntityTag;
@@ -128,6 +134,7 @@ class SmaccerHandler {
 
 	private array $npcs = [
 		'Allay' => AllaySmaccer::class,
+		'ArmorStand' => ArmorStandSmaccer::class,
 		'Armadillo' => ArmadilloSmaccer::class,
 		'Axolotl' => AxolotlSmaccer::class,
 		'Bat' => BatSmaccer::class,
@@ -136,10 +143,12 @@ class SmaccerHandler {
 		'Bogged' => BoggedSmaccer::class,
 		'Breeze' => BreezeSmaccer::class,
 		'Camel' => CamelSmaccer::class,
+		'CamelHusk' => CamelHuskSmaccer::class,
 		'Cat' => CatSmaccer::class,
 		'CaveSpider' => CaveSpiderSmaccer::class,
 		'Chicken' => ChickenSmaccer::class,
 		'Cod' => CodSmaccer::class,
+		'CopperGolem' => CopperGolemSmaccer::class,
 		'Cow' => CowSmaccer::class,
 		'Creaking' => CreakingSmaccer::class,
 		'Creeper' => CreeperSmaccer::class,
@@ -147,6 +156,7 @@ class SmaccerHandler {
 		'Donkey' => DonkeySmaccer::class,
 		'Drowned' => DrownedSmaccer::class,
 		'ElderGuardian' => ElderGuardianSmaccer::class,
+		'ElderGuardianGhost' => ElderGuardianGhostSmaccer::class,
 		'EnderDragon' => EnderDragonSmaccer::class,
 		'Enderman' => EndermanSmaccer::class,
 		'Endermite' => EndermiteSmaccer::class,
@@ -154,6 +164,7 @@ class SmaccerHandler {
 		'Fox' => FoxSmaccer::class,
 		'Frog' => FrogSmaccer::class,
 		'Ghast' => GhastSmaccer::class,
+		'HappyGhast' => HappyGhastSmaccer::class,
 		'GlowSquid' => GlowSquidSmaccer::class,
 		'Goat' => GoatSmaccer::class,
 		'Guardian' => GuardianSmaccer::class,
@@ -206,6 +217,7 @@ class SmaccerHandler {
 		'Wolf' => WolfSmaccer::class,
 		'Zoglin' => ZoglinSmaccer::class,
 		'ZombieHorse' => ZombieHorseSmaccer::class,
+		'ZombiePigman' => ZombiePigmanSmaccer::class,
 		'Zombie' => ZombieSmaccer::class,
 		'ZombieVillager' => ZombieVillagerSmaccer::class,
 		'ZombieVillagerV2' => ZombieVillagerV2Smaccer::class,

--- a/src/aiptu/smaccer/entity/npc/ArmorStandSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/ArmorStandSmaccer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntitySmaccer;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class ArmorStandSmaccer extends EntitySmaccer {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return 1.975;
+	}
+
+	public function getWidth() : float {
+		return 0.5;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::ARMOR_STAND;
+	}
+
+	public function getName() : string {
+		return 'Armor Stand';
+	}
+}

--- a/src/aiptu/smaccer/entity/npc/CamelHuskSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/CamelHuskSmaccer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntityAgeable;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class CamelHuskSmaccer extends EntityAgeable {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return $this->isBaby() ? 1.06875 : 2.375;
+	}
+
+	public function getWidth() : float {
+		return $this->isBaby() ? 0.765 : 1.7;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::CAMEL_HUSK;
+	}
+
+	public function getName() : string {
+		return 'Camel Husk';
+	}
+
+	public function getBabyScale() : float {
+		return 0.45;
+	}
+}

--- a/src/aiptu/smaccer/entity/npc/CopperGolemSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/CopperGolemSmaccer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntitySmaccer;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class CopperGolemSmaccer extends EntitySmaccer {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return 1.4;
+	}
+
+	public function getWidth() : float {
+		return 0.6;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::COPPER_GOLEM;
+	}
+
+	public function getName() : string {
+		return 'Copper Golem';
+	}
+}

--- a/src/aiptu/smaccer/entity/npc/ElderGuardianGhostSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/ElderGuardianGhostSmaccer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntitySmaccer;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class ElderGuardianGhostSmaccer extends EntitySmaccer {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return 1.9975;
+	}
+
+	public function getWidth() : float {
+		return 1.9975;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::ELDER_GUARDIAN_GHOST;
+	}
+
+	public function getName() : string {
+		return 'Elder Guardian Ghost';
+	}
+}

--- a/src/aiptu/smaccer/entity/npc/HappyGhastSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/HappyGhastSmaccer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntitySmaccer;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class HappyGhastSmaccer extends EntitySmaccer {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return 2.0;
+	}
+
+	public function getWidth() : float {
+		return 2.0;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::HAPPY_GHAST;
+	}
+
+	public function getName() : string {
+		return 'Happy Ghast';
+	}
+}

--- a/src/aiptu/smaccer/entity/npc/ZombiePigmanSmaccer.php
+++ b/src/aiptu/smaccer/entity/npc/ZombiePigmanSmaccer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2024-2025 AIPTU
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/AIPTU/Smaccer
+ */
+
+declare(strict_types=1);
+
+namespace aiptu\smaccer\entity\npc;
+
+use aiptu\smaccer\entity\EntityAgeable;
+use pocketmine\entity\EntitySizeInfo;
+use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
+
+class ZombiePigmanSmaccer extends EntityAgeable {
+	protected function getInitialSizeInfo() : EntitySizeInfo {
+		return new EntitySizeInfo($this->getHeight(), $this->getWidth());
+	}
+
+	public function getHeight() : float {
+		return $this->isBaby() ? 0.975 : 1.95;
+	}
+
+	public function getWidth() : float {
+		return $this->isBaby() ? 0.3 : 0.6;
+	}
+
+	public static function getNetworkTypeId() : string {
+		return EntityIds::ZOMBIE_PIGMAN;
+	}
+
+	public function getName() : string {
+		return 'Zombie Pigman';
+	}
+
+	public function getBabyScale() : float {
+		return 0.5;
+	}
+}


### PR DESCRIPTION
Added smaccer entities:

- ArmorStand
- CamelHusk
- CopperGolem
- ElderGuardianGhost
- HappyGhast
- ZombiePigman

## Summary by Sourcery

Add support for additional smaccer NPC entity types and register them in the central handler.

New Features:
- Introduce ArmorStand, CamelHusk, CopperGolem, ElderGuardianGhost, HappyGhast, and ZombiePigman smaccer NPC entities with appropriate metadata and sizing.
- Register the new smaccer NPC entities in SmaccerHandler so they can be instantiated and used by name.